### PR TITLE
Move perform to request

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -54,7 +54,7 @@ struct EstablishmentsResponse {
 }
 
 extension EstablishmentsResponse: Parsable {
-    static func parse(fromData data: Data?, withStatus status: Int, headers: [String: String]?) -> Result<EstablishmentsResponse> {
+    static func parse(from data: Data?, status: Int, headers: [String: String]?) -> Result<EstablishmentsResponse> {
         if status != 200 {
             return .failure(EstablishmentParseError.non200Response)
         }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         let request = EstablishmentRequest()
-        get(request) { (result: Result<EstablishmentsResponse>) in
+        request.perform { (result: Result<EstablishmentsResponse>) in
             switch result {
             case .success(let response):
                 response.establishments.forEach { est in

--- a/Fetch/Fetch.swift
+++ b/Fetch/Fetch.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 private extension Request {
-    func urlRequest(_ method: String) -> URLRequest {
+    func urlRequest() -> URLRequest {
         var request = URLRequest(url: url as URL)
         if let headers = headers {
             request.allHTTPHeaderFields = headers
@@ -17,45 +17,33 @@ private extension Request {
         if let body = body {
             request.httpBody = body
         }
-        request.httpMethod = method
+        request.httpMethod = method.rawValue
         return request
     }
 }
 
-private func makeRequest<T: Parsable>(_ request: Request, method: String, session: URLSession, responseQueue: OperationQueue, completion: @escaping (Result<T>) -> Void) {
-    let request = request.urlRequest(method)
-    let task = session.dataTask(with: request, completionHandler: { data, response, error in
-        if let error = error {
-            completion(.failure(error))
-            return
-        }
-        guard let actualResponse = response as? HTTPURLResponse else {
-            fatalError("Response is not an HTTP response")
-        }
-        let result = T.parse(fromData: data, withStatus: actualResponse.statusCode, headers: actualResponse.allHeaderFields as? [String: String])
-        responseQueue.addOperation {
-            completion(result)
-        }
-    })
-    task.resume()
-}
+public extension Request {
 
-/**
- Make a HTTP GET request for the resource specified by `request`
-
- - parameter request:    The request to make
- - parameter completion: The callback to call on completion
- */
-public func get<T: Parsable>(_ request: Request, session: URLSession = URLSession.shared, responseQueue: OperationQueue = OperationQueue.main, completion: @escaping (Result<T>) -> Void) {
-    makeRequest(request, method: "GET", session: session, responseQueue: responseQueue, completion: completion)
-}
-
-/**
- Make a HTTP POST request for the resource specified by `request`
-
- - parameter request:    The request to make
- - parameter completion: The callback to call on completion
- */
-public func post<T: Parsable>(_ request: Request, session: URLSession = URLSession.shared, responseQueue: OperationQueue = OperationQueue.main, completion: @escaping (Result<T>) -> Void) {
-    makeRequest(request, method: "POST", session: session, responseQueue: responseQueue, completion: completion)
+    /// Make an HTTP request for the resource described by this `Request`
+    ///
+    /// - Parameters:
+    ///   - session: The URL session to use
+    ///   - responseQueue: The queue to  send the response on
+    ///   - completion: The completion block to call with the response
+    public func perform<T: Parsable>(session: URLSession = URLSession.shared, responseQueue: OperationQueue = OperationQueue.main, completion: @escaping (Result<T>) -> Void) {
+        let task = session.dataTask(with: urlRequest(), completionHandler: { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let actualResponse = response as? HTTPURLResponse else {
+                fatalError("Response is not an HTTP response")
+            }
+            let result = T.parse(fromData: data, withStatus: actualResponse.statusCode, headers: actualResponse.allHeaderFields as? [String: String])
+            responseQueue.addOperation {
+                completion(result)
+            }
+        })
+        task.resume()
+    }
 }

--- a/Fetch/Fetch.swift
+++ b/Fetch/Fetch.swift
@@ -39,7 +39,7 @@ public extension Request {
             guard let actualResponse = response as? HTTPURLResponse else {
                 fatalError("Response is not an HTTP response")
             }
-            let result = T.parse(fromData: data, withStatus: actualResponse.statusCode, headers: actualResponse.allHeaderFields as? [String: String])
+            let result = T.parse(from: data, status: actualResponse.statusCode, headers: actualResponse.allHeaderFields as? [String: String])
             responseQueue.addOperation {
                 completion(result)
             }

--- a/Fetch/Parsable.swift
+++ b/Fetch/Parsable.swift
@@ -20,6 +20,6 @@ public protocol Parsable {
      - parameter status:  The HTTP status code received
      - parameter headers: The HTTP headers received
      */
-    static func parse(fromData data: Data?, withStatus status: Int, headers: [String: String]?) -> Result<Self>
+    static func parse(from data: Data?, status: Int, headers: [String: String]?) -> Result<Self>
 
 }

--- a/FetchTests/FetchTests.swift
+++ b/FetchTests/FetchTests.swift
@@ -47,7 +47,7 @@ struct TestResponse: Parsable {
     let desc: String
     let headers: [String: String]?
 
-    static func parse(fromData data: Data?, withStatus status: Int, headers: [String: String]?) -> Result<TestResponse> {
+    static func parse(from data: Data?, status: Int, headers: [String: String]?) -> Result<TestResponse> {
         if status != 200 {
             return .failure(Fail.statusFail)
         }

--- a/FetchTests/FetchTests.swift
+++ b/FetchTests/FetchTests.swift
@@ -27,7 +27,7 @@ struct TestRequest: Request {
         self.init(url: url, headers: nil, body: nil)
     }
 
-    init(url: URL, method: HTTPMethod = .get, headers: [String: String]?, body: Data?) {
+    init(url: URL, method: HTTPMethod = .get, headers: [String: String]? = nil, body: Data? = nil) {
         self.url = url
         self.method = method
         self.headers = headers
@@ -81,7 +81,7 @@ class FetchTests: XCTestCase {
         }
         let exp = expectation(description: "get request")
         var receivedResult: Result<TestResponse>?
-        Fetch.get(request) { (result: Result<TestResponse>) in
+        request.perform { (result: Result<TestResponse>) in
             receivedResult = result
             exp.fulfill()
         }
@@ -114,7 +114,7 @@ class FetchTests: XCTestCase {
         }
         let exp = expectation(description: "post request")
         var receivedResult: Result<TestResponse>?
-        Fetch.post(basicRequest) { (result: Result<TestResponse>) in
+        TestRequest(url: testURL, method: .post).perform { (result: Result<TestResponse>) in
             receivedResult = result
             exp.fulfill()
         }
@@ -177,13 +177,13 @@ class FetchTests: XCTestCase {
 
     func testBodyIsPassedToTheRequest() {
         let testBody = "test body"
-        let testRequest = TestRequest(url: testURL, headers: nil, body: testBody.data(using: String.Encoding.utf8))
+        let testRequest = TestRequest(url: testURL, method: .post, headers: nil, body: testBody.data(using: String.Encoding.utf8))
 
         stubRequest { (request) -> Bool in
             return request.url! == testURL && request.httpMethod == "POST"
         }
         let mockSession = MockSession()
-        Fetch.post(testRequest, session: mockSession) { (_: Result<TestResponse>) in
+        testRequest.perform(session: mockSession) { (_: Result<TestResponse>) in
         }
         expect(mockSession.receivedBody).to(equal(testBody))
     }
@@ -195,7 +195,7 @@ class FetchTests: XCTestCase {
         }
         let exp = expectation(description: "post request")
         var receivedQueue: OperationQueue?
-        Fetch.post(basicRequest, responseQueue: callBackQueue) { (_: Result<TestResponse>) in
+        TestRequest(url: testURL, method: .post).perform(responseQueue: callBackQueue) { (_: Result<TestResponse>) in
             receivedQueue = OperationQueue.current
             exp.fulfill()
         }


### PR DESCRIPTION
This now uses the method on the request to create the URLRequest. This is just a minor refactor before we add the ability to cancel requests as well.