### PR TITLE
Pass userInfo from Request to Parsable

### DIFF
--- a/Fetch.xcodeproj/project.pbxproj
+++ b/Fetch.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		45D71D101C722987009059C2 /* OHHTTPStubs.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 45D71D051C71E9CA009059C2 /* OHHTTPStubs.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		45D71D131C722AAD009059C2 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45D71D121C722AAD009059C2 /* Nimble.framework */; };
 		45D71D141C722AB6009059C2 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 45D71D121C722AAD009059C2 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		96154EF81FBC824500B6B4F3 /* UserInfoProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96154EF71FBC824500B6B4F3 /* UserInfoProviding.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -112,6 +113,7 @@
 		07A399961C70976800896C87 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		45D71D051C71E9CA009059C2 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = SOURCE_ROOT; };
 		45D71D121C722AAD009059C2 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
+		96154EF71FBC824500B6B4F3 /* UserInfoProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoProviding.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,6 +181,7 @@
 				0764F7EF1FB98C4D006AA048 /* BasicURLRequest.swift */,
 				072B885C1FB9E37300E66676 /* URL+QueryItems.swift */,
 				072B88601FB9F86B00E66676 /* ErrorParsing.swift */,
+				96154EF71FBC824500B6B4F3 /* UserInfoProviding.swift */,
 			);
 			path = Fetch;
 			sourceTree = "<group>";
@@ -394,6 +397,7 @@
 				0764F7DE1FB71D96006AA048 /* Session.swift in Sources */,
 				0764F7EA1FB852ED006AA048 /* ResponseError.swift in Sources */,
 				0764F7E41FB84DF9006AA048 /* UIImage+Parsable.swift in Sources */,
+				96154EF81FBC824500B6B4F3 /* UserInfoProviding.swift in Sources */,
 				072B885D1FB9E37300E66676 /* URL+QueryItems.swift in Sources */,
 				071F203E1C6F878400BBCBAF /* Parsable.swift in Sources */,
 				07A399971C70976800896C87 /* Result.swift in Sources */,

--- a/Fetch/BasicURLRequest.swift
+++ b/Fetch/BasicURLRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Simple implementation of `Request` for scenarios where you just need to perform
 /// a request with a URL rather than creating specific domain requests
-public struct BasicURLRequest: Request {
+public struct BasicURLRequest: Request, UserInfoProviding {
     public let url: URL
 
     public let method: HTTPMethod
@@ -19,10 +19,13 @@ public struct BasicURLRequest: Request {
 
     public let body: Data?
 
-    public init(url: URL, method: HTTPMethod = .get, headers: [String: String]? = nil, body: Data? = nil) {
+    public let userInfo: [String: Any]?
+
+    public init(url: URL, method: HTTPMethod = .get, headers: [String: String]? = nil, body: Data? = nil, userInfo: [String: Any]? = nil) {
         self.url = url
         self.method = method
         self.headers = headers
         self.body = body
+        self.userInfo = userInfo
     }
 }

--- a/Fetch/Parsable.swift
+++ b/Fetch/Parsable.swift
@@ -20,7 +20,8 @@ public protocol Parsable {
      - parameter status:  The HTTP status code received
      - parameter headers: The HTTP headers received
      - parameter errorParser: Object used to parse errors
+     - parameter userInfo: A userInfo dictionary attached to the request.
      */
-    static func parse(from data: Data?, status: Int, headers: [String: String]?, errorParser: ErrorParsing.Type?) -> Result<Self>
+    static func parse(from data: Data?, status: Int, headers: [String: String]?, errorParser: ErrorParsing.Type?, userInfo: [String: Any]?) -> Result<Self>
 
 }

--- a/Fetch/Session.swift
+++ b/Fetch/Session.swift
@@ -69,7 +69,12 @@ public class Session: RequestPerforming {
                 result = .failure(SessionError.unknownResponseType)
                 return
             }
-            result = T.parse(from: data, status: actualResponse.statusCode, headers: actualResponse.allHeaderFields as? [String: String], errorParser: errorParser)
+            let userInfo = (request as? UserInfoProviding)?.userInfo
+            result = T.parse(from: data,
+                             status: actualResponse.statusCode,
+                             headers: actualResponse.allHeaderFields as? [String: String],
+                             errorParser: errorParser,
+                             userInfo: userInfo)
 
         })
         tasks[taskIdentifier] = task
@@ -89,7 +94,7 @@ enum SessionError: Error {
 
 private extension Request {
     func urlRequest() -> URLRequest {
-        var request = URLRequest(url: url as URL)
+        var request = URLRequest(url: url)
         if let headers = headers {
             request.allHTTPHeaderFields = headers
         }

--- a/Fetch/UIImage+Parsable.swift
+++ b/Fetch/UIImage+Parsable.swift
@@ -14,14 +14,14 @@ public enum ImageParseError: Error {
 }
 
 /// Box structure to get around the error:
-/// Protocol 'Parsable' requirement 'parse(from:status:headers:)' cannot be satisfied by a non-final class ('UIImage') because it uses 'Self' in a non-parameter, non-result type position
+/// Protocol 'Parsable' requirement 'parse(from:status:headers:errorParser:userInfo:)' cannot be satisfied by a non-final class ('UIImage') because it uses 'Self' in a non-parameter, non-result type position
 /// meaning we can't extend UIImage directly with `Parsable` as it's `open`
 public struct Image {
     public let image: UIImage
 }
 
 extension Image: Parsable {
-    public static func parse(from data: Data?, status: Int, headers: [String: String]?, errorParser: ErrorParsing.Type?) -> Result<Image> {
+    public static func parse(from data: Data?, status: Int, headers: [String: String]?, errorParser: ErrorParsing.Type?, userInfo: [String: Any]?) -> Result<Image> {
         guard status < 400 else {
             return .failure(ResponseError.statusCode(status))
         }

--- a/Fetch/UserInfoProviding.swift
+++ b/Fetch/UserInfoProviding.swift
@@ -1,0 +1,16 @@
+//
+//  UserInfoProviding.swift
+//  Fetch
+//
+//  Created by Sebastian Skuse on 15/11/2017.
+//  Copyright © 2017 David Hardiman. All rights reserved.
+//
+
+import Foundation
+
+/// Describes something that can provide a userInfo dictionary.
+/// If a Request conforms to UserInfoProviding information will
+/// be passed through to the Parsable.
+public protocol UserInfoProviding {
+    var userInfo: [String: Any]? { get }
+}

--- a/FetchTests/UIImageParsingTests.swift
+++ b/FetchTests/UIImageParsingTests.swift
@@ -17,14 +17,14 @@ class UIImageParsingTests: XCTestCase {
             let data = UIImagePNGRepresentation(testImage) else {
             return fail("Couldn't parse test image")
         }
-        guard case .success(let image) = Image.parse(from: data, status: 200, headers: nil, errorParser: nil) else {
+        guard case .success(let image) = Image.parse(from: data, status: 200, headers: nil, errorParser: nil, userInfo: nil) else {
             return fail("Expected a successful response")
         }
         expect(UIImagePNGRepresentation(image.image)).to(equal(data))
     }
 
     func testItReturnsAnErrorForNonSuccessStatus() {
-        guard case .failure(let error) = Image.parse(from: nil, status: 400, headers: nil, errorParser: nil) else {
+        guard case .failure(let error) = Image.parse(from: nil, status: 400, headers: nil, errorParser: nil, userInfo: nil) else {
             return fail("Expected a failure")
         }
         guard let responseError = error as? ResponseError else {
@@ -37,7 +37,7 @@ class UIImageParsingTests: XCTestCase {
     }
 
     func testItReturnsAParseErrorForBadImageData() {
-        guard case .failure(let error) = Image.parse(from: Data(), status: 200, headers: nil, errorParser: nil) else {
+        guard case .failure(let error) = Image.parse(from: Data(), status: 200, headers: nil, errorParser: nil, userInfo: nil) else {
             return fail("Expected a failure")
         }
         guard let parseError = error as? ImageParseError else {
@@ -47,7 +47,7 @@ class UIImageParsingTests: XCTestCase {
     }
 
     func testItReturnsAnErrorForNoImageData() {
-        guard case .failure(let error) = Image.parse(from: nil, status: 200, headers: nil, errorParser: nil) else {
+        guard case .failure(let error) = Image.parse(from: nil, status: 200, headers: nil, errorParser: nil, userInfo: nil) else {
             return fail("Expected a failure")
         }
         guard let parseError = error as? ImageParseError else {

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ struct UserRequest: Request {
 ```
 
 ## `Parsable`
-This is the protocol to use when creating a request. It has a single function, `static func parse(from data: Data?, status: Int, headers: [String: String]?, errorParser: ErrorParsing?) -> Result<Self>`, which is intended to interpret the data and status code received from the successful request. Implement this method to determine success or failure and to populate a model object with data. For example, if parsing a response from our user request above, you might create the following:
-  
+This is the protocol to use when creating a request. It has a single function, `static func parse(from data: Data?, status: Int, headers: [String: String]?, errorParser: ErrorParsing?, userInfo: [String: Any]?) -> Result<Self>`, which is intended to interpret the data and status code received from the successful request. Implement this method to determine success or failure and to populate a model object with data. For example, if parsing a response from our user request above, you might create the following:
+
 ```swift
 struct User {
   let id: Int
@@ -38,7 +38,7 @@ extension User: Parsable {
     case parseError
   }
   
-  static func parse(from data: Data?, status: Int, headers: [String: String]?, errorParser: ErrorParsing?) -> Result<User> {
+  static func parse(from data: Data?, status: Int, headers: [String: String]?, errorParser: ErrorParsing?, userInfo: [String: Any]?) -> Result<User> {
     guard status == 200 else {
       // Parse data for any error message
       if let error = errorParser.parseError(from: data, status: status) {
@@ -101,8 +101,11 @@ There is an example app in the project which shows you how to implement `Parsabl
 The easiest way to use this library is via Carthage. Just add
 
     github "dhardiman/Fetch"
+to your Cartfile.
 
-to your Cartfile
+When building and running tests locally, make sure to initialise Carthage dependencies with:
+
+`carthage bootstrap --platform iOS`
 
 ## License
 [MIT](LICENSE.md) 


### PR DESCRIPTION
Adds a new `UserInfoProviding` protocol, which `Requests` can conform to. Adding conformance passes the `userInfo` through to the Parsable.