### PR TITLE
Resolve BaseURL in appending(queryItems:)

### DIFF
--- a/Fetch/URL+QueryItems.swift
+++ b/Fetch/URL+QueryItems.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension URL {
     public func appending(queryItems: [URLQueryItem]) -> URL {
-        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
             return self
         }
         components.queryItems = queryItems

--- a/FetchTests/URLQueryItemTests.swift
+++ b/FetchTests/URLQueryItemTests.swift
@@ -16,4 +16,10 @@ class URLQueryItemTests: XCTestCase {
         let receivedURL = url?.appending(queryItems: [URLQueryItem(name: "test", value: "test")])
         expect(receivedURL?.absoluteString).to(equal("https://www.test.com?test=test"))
     }
+
+    func testUsingAConstructedURLAllowsQueryItemsToBeAppended() {
+        let url = URL(string: "endpoint.json", relativeTo: URL(string: "https://www.test.com"))
+        let receivedURL = url?.appending(queryItems: [URLQueryItem(name: "test", value: "test")])
+        expect(receivedURL?.absoluteString).to(equal("https://www.test.com/endpoint.json?test=test"))
+    }
 }


### PR DESCRIPTION
Ensures that URL's created with `URL(string:relativeTo:)` work with `URL.appending(queryItems:)`