### PR TITLE
Cancel tasks from inside taskQueue

### DIFF
--- a/Fetch/Session.swift
+++ b/Fetch/Session.swift
@@ -94,8 +94,8 @@ public class Session: RequestPerforming {
     }
 
     public func cancelAllTasks() {
-        tasks.values.forEach { $0.cancel() }
         self.taskQueue.sync {
+            tasks.values.forEach { $0.cancel() }
             tasks.removeAll()
         }
     }


### PR DESCRIPTION
Fixes a race condition where the tasks array is being iterated at the same time it's being purged causing a crash in ```_NativeDictionaryBuffer.assertingGet(_NativeDictionaryIndex<A, B>) -> (key : A, value : B)```