### PR TITLE
Add @backDeployed attribute to URL query items function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
   iOStest:
     macos:
-      xcode: "13.0.0"
+      xcode: "15.0.0"
     steps:
       - checkout
       - run: bundle install
       - run:
           name: Run Tests
           command: |
-              xcodebuild -destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' -sdk iphonesimulator -scheme "Fetch-iOS" clean test |
+              xcodebuild -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' -sdk iphonesimulator -scheme "Fetch-iOS" clean test |
               tee xcodebuild.log |
               xcpretty --report html --output test_output/results.html --report junit --output test_output/unit-tests/results.xml
       - run:
@@ -23,7 +23,7 @@ jobs:
           path: xcodebuild.log
   tvOStest:
     macos:
-      xcode: "13.0.0"
+      xcode: "15.0.0"
     steps:
       - checkout
       - run:
@@ -33,7 +33,7 @@ jobs:
               tee xcodebuild.log
   macOStest:
     macos:
-      xcode: "13.0.0"
+      xcode: "15.0.0"
     steps:
       - checkout
       - run:

--- a/Sources/Fetch/URL+QueryItems.swift
+++ b/Sources/Fetch/URL+QueryItems.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public extension URL {
+    @backDeployed(before: iOS 16, tvOS 16, macOS 13)
     func appending(queryItems: [URLQueryItem]) -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
             return self


### PR DESCRIPTION
When building with a minimum deployment target of iOS 16+, Xcode does not know whether to use the `-[URL appendingQueryItems:]` function from Fetch or [Foundation](https://developer.apple.com/documentation/foundation/url/3988450-appending). This change adds the `@backDeployed` attribute to the function in Fetch, so that Xcode knows to ignore Fetch's version when targeting iOS 16 or higher.