### PR TITLE
Allows filename to be omitted from MultipartFormDataSection header if it's nil

### DIFF
--- a/Sources/Fetch/Requests/MultiPartFormRequest.swift
+++ b/Sources/Fetch/Requests/MultiPartFormRequest.swift
@@ -54,10 +54,10 @@ public struct MultipartFormDataSection {
     let contentType: String
     let charset: String
     let name: String
-    let filename: String
+    let filename: String?
     let content: Data
 
-    public init(contentType: String = "text/plain", charset: String = "utf-8", name: String, filename: String, content: Data) {
+    public init(contentType: String = "text/plain", charset: String = "utf-8", name: String, filename: String?, content: Data) {
         self.contentType = contentType
         self.charset = charset
         self.name = name
@@ -66,9 +66,16 @@ public struct MultipartFormDataSection {
     }
 
     var data: Data {
+        let contentDisposition: String
+        if let filename {
+            contentDisposition = "form-data; name=\"\(name)\"; filename=\"\(filename)\""
+        } else {
+            contentDisposition = "form-data; name=\"\(name)\""
+        }
+
         let headers = [
             "Content-Type: \(contentType); charset=\(charset)",
-            #"Content-Disposition: form-data; name="\#(name)";filename="\#(filename)""#
+            "Content-Disposition: \(contentDisposition)"
         ]
         var output = Data()
         output.append(headers.joined(separator: newLine).data(using: .utf8)!)

--- a/Tests/FetchTests/MultiPartFormRequestTests.swift
+++ b/Tests/FetchTests/MultiPartFormRequestTests.swift
@@ -20,7 +20,7 @@ class MultiPartFormRequestTests: XCTestCase {
         let request = MultiPartFormRequest(url: testURL, sections: [
             MultipartFormDataSection(name: "testfile", filename: "testfile.txt", content: "test".data(using: .utf8)!)
         ])
-        let expectedString = "--\(MultiPartFormHeader.boundary)\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Disposition: form-data; name=\"testfile\";filename=\"testfile.txt\"\r\n\r\ntest\r\n--\(MultiPartFormHeader.boundary)\r\n"
+        let expectedString = "--\(MultiPartFormHeader.boundary)\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Disposition: form-data; name=\"testfile\"; filename=\"testfile.txt\"\r\n\r\ntest\r\n--\(MultiPartFormHeader.boundary)\r\n"
         expect(request.body).to(equal(expectedString.data(using: .utf8)))
     }
 
@@ -29,10 +29,19 @@ class MultiPartFormRequestTests: XCTestCase {
             MultipartFormDataSection(name: "testfile", filename: "testfile.txt", content: "test".data(using: .utf8)!),
             MultipartFormDataSection(contentType: "test-type", charset: "testset", name: "second test", filename: "second-test.txt", content: "another-test".data(using: .utf8)!)
         ])
-        let expectedString = "--\(MultiPartFormHeader.boundary)\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Disposition: form-data; name=\"testfile\";filename=\"testfile.txt\"\r\n\r\ntest\r\n--\(MultiPartFormHeader.boundary)\r\nContent-Type: test-type; charset=testset\r\nContent-Disposition: form-data; name=\"second test\";filename=\"second-test.txt\"\r\n\r\nanother-test\r\n--\(MultiPartFormHeader.boundary)\r\n"
+        let expectedString = "--\(MultiPartFormHeader.boundary)\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Disposition: form-data; name=\"testfile\"; filename=\"testfile.txt\"\r\n\r\ntest\r\n--\(MultiPartFormHeader.boundary)\r\nContent-Type: test-type; charset=testset\r\nContent-Disposition: form-data; name=\"second test\"; filename=\"second-test.txt\"\r\n\r\nanother-test\r\n--\(MultiPartFormHeader.boundary)\r\n"
         expect(request.body).to(equal(expectedString.data(using: .utf8)))
     }
-    
+
+    func testItConvertsSectionsForTheBodyCorrectlyWhenFileNameIsNil() {
+        let request = MultiPartFormRequest(url: testURL, sections: [
+            MultipartFormDataSection(name: "testfile", filename: nil, content: "test".data(using: .utf8)!)
+        ])
+        let expectedString = "--\(MultiPartFormHeader.boundary)\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Disposition: form-data; name=\"testfile\"\r\n\r\ntest\r\n--\(MultiPartFormHeader.boundary)\r\n"
+        expect(request.body).to(equal(expectedString.data(using: .utf8)))
+    }
+
+
     func testItMergesAdditionalHeadersWithTheGeneratedContentTypeHeader() {
         let request = MultiPartFormRequest(url: testURL, sections: [], additionalHeaders: ["gregg": "wallace"])
         expect(request.headers?["Content-Type"]).to(equal("multipart/form-data; boundary=__fetch_boundary_token__"))


### PR DESCRIPTION
This PR removes the filename from the multipart header when there is no associated file name.

Why?

The multipart specification makes the filename parameter in the "Content-Disposition:" header optional.
For sections with a content type of "application/json," a filename is not applicable, and its presence may cause issues.
